### PR TITLE
Add link to fuzzbench repo to deal with bad blogpost link

### DIFF
--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -1,1 +1,1 @@
-Looking for [fuzzbench fuzzers](https://github.com/google/fuzzbench/tree/master/fuzzers)?.
+Looking for [fuzzbench fuzzers](https://github.com/google/fuzzbench/tree/master/fuzzers)?

--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -1,0 +1,1 @@
+Looking for [fuzzbench fuzzers](https://github.com/google/fuzzbench/tree/master/fuzzers)?.


### PR DESCRIPTION
Temporary workaround bad blogpost link