### PR TITLE
[split inputs] Update documentation for FDP->ConsumeRandomLengthString.

### DIFF
--- a/docs/split-inputs.md
+++ b/docs/split-inputs.md
@@ -186,7 +186,7 @@ are left inside the provider object by calling `remaining_bytes()` method on it.
   the resulting object is the best way to obtain it.
 * `ConsumeRandomLengthString` method returns a `std::string` as well, but its
   length is derived from the fuzz input and typically is hard to predict, though
-  always deterministic. The caller must provide the max length argument.
+  always deterministic. The caller can provide the max length argument.
 * `ConsumeRemainingBytes` and `ConsumeRemainingBytesAsString` methods return
   `std::vector` and `std::string` objects respectively, initialized with all the
   bytes from the fuzz input that left unused.


### PR DESCRIPTION
The new variant without an argument was added in https://github.com/llvm/llvm-project/commit/2136d17d8dec4b5bd47d2ba2b48866c34c55e56d