### PR TITLE
Fixing Bug in ASN.1 Universal Types

### DIFF
--- a/proto/asn1-pdu/asn1_universal_types_to_der.cc
+++ b/proto/asn1-pdu/asn1_universal_types_to_der.cc
@@ -113,9 +113,8 @@ void EncodeTimestamp(const google::protobuf::Timestamp& timestamp,
   time_str += "Z";
 
   der.reserve(der.size() + time_str.size());
-  std::transform(
-      time_str.begin(), time_str.end(), der.end(),
-      [](char c) -> auto { return static_cast<uint8_t>(c); });
+  std::transform(time_str.begin(), time_str.end(), std::back_inserter(der),
+                 [](char c) -> size_t { return c; });
 }
 
 }  // namespace asn1_universal_types


### PR DESCRIPTION
For `transform` instead if passing in `der.end()` we use `std::back_inserter` which is a back insert iterator that allows algorithm to insert new elements at the end of the container.