### PR TITLE
Fixing Bugs in ASN.1 PDU, ASN.1 Universal Types, and X.509 Certificate

### DIFF
--- a/proto/asn1-pdu/asn1_pdu.proto
+++ b/proto/asn1-pdu/asn1_pdu.proto
@@ -43,7 +43,6 @@ message TagNumber {
 }
 
 enum LowTagNumber {
-  VAL0 = 0;
   VAL1 = 1;
   VAL2 = 2;
   VAL3 = 3;

--- a/proto/asn1-pdu/asn1_pdu.proto
+++ b/proto/asn1-pdu/asn1_pdu.proto
@@ -43,6 +43,7 @@ message TagNumber {
 }
 
 enum LowTagNumber {
+  VAL0 = 0;
   VAL1 = 1;
   VAL2 = 2;
   VAL3 = 3;

--- a/proto/asn1-pdu/asn1_universal_types_to_der.cc
+++ b/proto/asn1-pdu/asn1_universal_types_to_der.cc
@@ -111,7 +111,7 @@ void Encode(const UTCTime& utc_time, std::vector<uint8_t>& der) {
   // after the value is encoded.
   const size_t tag_len_pos = der.size();
 
-  EncodeTimestamp(utc_time.time_stamp(), false, der);
+  EncodeTimestamp(utc_time.time_stamp(), true, der);
 
   // Check if encoding was successful.
   if (der.size() != tag_len_pos) {
@@ -126,7 +126,7 @@ void Encode(const GeneralizedTime& generalized_time,
   // after the value is encoded.
   const size_t tag_len_pos = der.size();
 
-  EncodeTimestamp(generalized_time.time_stamp(), true, der);
+  EncodeTimestamp(generalized_time.time_stamp(), false, der);
 
   // Check if encoding was successful.
   if (der.size() != tag_len_pos) {

--- a/proto/asn1-pdu/x509_certificate_to_der.cc
+++ b/proto/asn1-pdu/x509_certificate_to_der.cc
@@ -307,13 +307,14 @@ DECLARE_ENCODE_FUNCTION(ValiditySequence) {
 }
 
 DECLARE_ENCODE_FUNCTION(VersionNumber) {
-  // RFC 5280, 4.1 & 4.1.2.1: |val| 0 is DEFAULT.
-  // (X.690 (2015), 11.5): DEFAULT value in a sequence field is not encoded.
+  // RFC 5280, 4.1 & 4.1.2.1:
+  // version         [0]  EXPLICIT Version DEFAULT v1,
+  // Version  ::=  INTEGER  {  v1(0), v2(1), v3(2)  }
+  //
+  // X.690 (2015), 11.5: DEFAULT value in a sequence field is not encoded
   if (val != 0) {
-    // |version| is Context-specific with tag number 0 (RFC 5280, 4.1
-    // & 4.1.2.1).
-    // Takes on values 0, 1 and 2, so only require length of 1 to
-    // encode it (RFC 5280, 4.1 & 4.1.2.1).
+    // Use a fixed buffer for the EXPLICIT encoding, since the version is always
+    // a one byte INTEGER.
     std::vector<uint8_t> der_version = {
         kAsn1ContextSpecific | kAsn1Constructed | 0x00, 0x03, kAsn1Integer,
         0x01, static_cast<uint8_t>(val)};


### PR DESCRIPTION
These fixes allow us to successfully pass [d2i_x509](https://source.chromium.org/chromium/chromium/src/+/master:third_party/boringssl/src/crypto/x509/x_x509.c;l=240?q=d2i_X509&ss=chromium%2Fchromium%2Fsrc) in BoringSSL.