### PR TITLE
fix svn install command for libfuzzer source code

### DIFF
--- a/tutorial/libFuzzerTutorial.md
+++ b/tutorial/libFuzzerTutorial.md
@@ -426,7 +426,7 @@ Try this with one of the crashes you have found previously.
 We recommend [Clang Coverage](http://clang.llvm.org/docs/SourceBasedCodeCoverage.html) to visualize and study your code coverage. A simple example:
 ```
 # Build you code for Clang Coverage; link it against a standalone driver for running fuzz targets.
-svn co http://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer Fuzzer
+svn export http://github.com/llvm/llvm-project/trunk/compiler-rt/lib/fuzzer Fuzzer
 clang -fprofile-instr-generate -fcoverage-mapping ~/fuzzing/tutorial/libFuzzer/fuzz_me.cc \
                                                   ~/Fuzzer/standalone/StandaloneFuzzTargetMain.c
 mkdir CORPUS # Create an empty corpus dir.


### PR DESCRIPTION
LLVM community has been moving from SVN to GitHub to host the source code.  (See https://llvm.org/docs/Proposals/GitHubMove.html)

So original svn command is not working anymore. 

![image](https://user-images.githubusercontent.com/38074777/117143155-1b2c4680-ade3-11eb-8c8e-45e7b3d974bb.png)

A workaround is to use `svn export` to fetch files from GitHub. Tested on my Ubuntu 16.04 server.

![image](https://user-images.githubusercontent.com/38074777/117144271-51b69100-ade4-11eb-992b-3bdfb5473e6f.png)
