### PR TITLE
Fix libFuzzerTutorial.md typo

### DIFF
--- a/tutorial/libFuzzerTutorial.md
+++ b/tutorial/libFuzzerTutorial.md
@@ -392,7 +392,7 @@ In either way, you may want to minimize your corpus,
 that is to create a subset of the corpus that has the same coverage. 
 
 ```shell
-mkdir NEW_CORPPUS
+mkdir NEW_CORPUS
 ./your-fuzzer NEW_CORPUS OLD_CORPUS -merge=1
 ```
 


### PR DESCRIPTION
Hi, 

While reading this markdown file, I noticed that it should be NEW_CORPUS, not NEW_CORPPUS.

Thanks,
sigridsw